### PR TITLE
Update to 1.1.3~ynh1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Adapted for usage within Yunohost. Might behave even weirder.
 - Jellyfin Statistics Plugin Integration
 
 
-**Shipped version:** 1.1.2~ynh1
+**Shipped version:** 1.1.3~ynh1
 
 ## Screenshots
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,7 +6,7 @@ id = "jellystat"
 name = "Jellystat"
 description.en = "A statistics dashboard for Jellyfin servers."
 
-version = "1.1.2~ynh1"
+version = "1.1.3~ynh1"
 
 maintainers = ["botagas"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -59,9 +59,6 @@ ram.runtime = "100M"
     [resources.install_dir]
     dir = "/var/www/jellystat"
     
-    [resources.data_dir]
-    dir = "/home/yunohost.app/jellystat"
-    
     [resources.permissions]
     main.url = "/"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -48,8 +48,8 @@ ram.runtime = "100M"
 [resources]
     [resources.sources]
     [resources.sources.main]
-    url = "https://github.com/CyferShepard/Jellystat/archive/refs/tags/1.1.2.tar.gz"
-    sha256 = "53c1ac04910af2df5ebd4b0a46ec1fd6c85c7e84986f4b2a53ff9e1d04fe1a57"
+    url = "https://github.com/CyferShepard/Jellystat/archive/refs/tags/1.1.3.tar.gz"
+    sha256 = "80a6f9386b2b41ccba1494fd6d51078b6b70fffb69946f2f66f6f218acdeb782"
     branch = "main"
     autoupdate.strategy = "latest_github_tag"
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -4,16 +4,10 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# Keep this path for calling _common.sh inside the execution's context of backup and restore scripts
 source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
 ynh_print_info "Declaring files to be backed up..."
-
-### N.B. : the following 'ynh_backup' calls are only a *declaration* of what needs
-### to be backuped and not an actual copy of any file. The actual backup that
-### creates and fills the archive with the files happens in the core after this
-### script is called. Hence ynh_backups calls take basically 0 seconds to run.
 
 #=================================================
 # BACKUP THE APP MAIN DIR

--- a/scripts/backup
+++ b/scripts/backup
@@ -14,7 +14,6 @@ ynh_print_info "Declaring files to be backed up..."
 #=================================================
 
 BACKUP_CORE_ONLY=0 ynh_backup "$install_dir"
-ynh_backup "$data_dir" --not-mandatory
 
 #=================================================
 # BACKUP SYSTEM CONFIGURATION

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -22,17 +22,6 @@ ynh_script_progression "Updating NGINX web server configuration..."
 ynh_config_change_url_nginx
 
 #=================================================
-# SPECIFIC MODIFICATIONS
-#=================================================
-
-# If the app references the installation URL (domain/path) in its configuration
-# For Jellystat, we assume environment variables handle the URL, and no additional changes are required.
-# Uncomment the block below if you need to replace specific paths in configuration files.
-
-# Example of modifying configuration:
-# ynh_replace_string --match_string="old_value" --replace_string="new_value" --target_file="/path/to/config/file"
-
-#=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."

--- a/scripts/install
+++ b/scripts/install
@@ -166,10 +166,10 @@ done
 ynh_print_info "Creating admin user..."
 API_TOKEN_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
 API_TOKEN=$(ynh_hide_warnings echo "$API_TOKEN_RESPONSE" | jq -r '.token')
-ynh_app_setting_set --app=$app --key=apitoken --value="$API_TOKEN"
+ynh_app_setting_set --key=apitoken --value="$API_TOKEN"
 API_KEY_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
 API_KEY=$(ynh_hide_warnings echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
-ynh_app_setting_set --app=$app --key=apikey --value="$API_KEY"
+ynh_app_setting_set --key=apikey --value="$API_KEY"
 
 # Debug the advanced state
 setup_state_response=$(curl -s -X GET http://127.0.0.1:$port/auth/isConfigured -H "Content-Type: application/json")

--- a/scripts/install
+++ b/scripts/install
@@ -81,7 +81,6 @@ ynh_replace --match="\"host\": \"\"" --replace="\"host\": \"$domain\"" --file="$
 ynh_replace --match="^const PORT = .*" --replace="const PORT = process.env.PORT || $port;" --file="$install_dir/backend/server.js"
 
 # Set up backupfolder according to source /classes/backup.js file
-mkdir -p "$data_dir"
 mkdir -p "$backup_dir"
 mkdir -p "$backup_data"
 
@@ -123,9 +122,6 @@ chown "$app:$app" "$install_dir/.env"
 # Adjust permissions for web-accessible directories
 # chown -R "$app:www-data" "$install_dir/backend"
 chown -R "$app:www-data" "$install_dir/dist"
-
-# Adjust permissions for data
-chown -R "$app:$app" "$data_dir"
 
 #=================================================
 # SET UP SYSTEMD SERVICE

--- a/scripts/install
+++ b/scripts/install
@@ -167,7 +167,7 @@ ynh_print_info "Creating admin user..."
 API_TOKEN_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
 API_TOKEN=$(ynh_hide_warnings echo "$API_TOKEN_RESPONSE" | jq -r '.token')
 ynh_app_setting_set --key=api_token --value="$API_TOKEN"
-API_KEY_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
+API_KEY_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
 API_KEY=$(ynh_hide_warnings echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
 ynh_app_setting_set --key=api_key --value="$API_KEY"
 

--- a/scripts/install
+++ b/scripts/install
@@ -164,10 +164,10 @@ done
 
 # Create the admin user
 ynh_print_info "Creating admin user..."
-API_TOKEN_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
+API_TOKEN_RESPONSE=$(ynh_hide_warnings curl --silent --show-error --fail -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
 API_TOKEN=$(ynh_hide_warnings echo "$API_TOKEN_RESPONSE" | jq -r '.token')
 ynh_app_setting_set --key=api_token --value="$API_TOKEN"
-API_KEY_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{\"name\": \"YunoHost\"}')
+API_KEY_RESPONSE=$(ynh_hide_warnings curl --silent --show-error --fail -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{\"name\": \"YunoHost\"}')
 API_KEY=$(ynh_hide_warnings echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
 ynh_app_setting_set --key=api_key --value="$API_KEY"
 

--- a/scripts/install
+++ b/scripts/install
@@ -164,9 +164,9 @@ done
 
 # Create the admin user
 ynh_print_info "Creating admin user..."
-curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}'
-API_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -d '{"name": "YunoHost"}'
-API_KEY=$(echo "$API_RESPONSE" | jq -r '.[-1].key')
+curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"})'
+API_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -d '{"name": "YunoHost"} --silent)'
+API_KEY=$(echo "$API_RESPONSE" | jq -r '.[-1].key' --silent)
 
 # Debug the advanced state
 setup_state_response=$(curl -s -X GET http://127.0.0.1:$port/auth/isConfigured -H "Content-Type: application/json")

--- a/scripts/install
+++ b/scripts/install
@@ -165,6 +165,8 @@ done
 # Create the admin user
 ynh_print_info "Creating admin user..."
 curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}'
+API_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -d '{"name": "YunoHost"}'
+API_KEY=$(echo "$API_RESPONSE" | jq -r '.[-1].key')
 
 # Debug the advanced state
 setup_state_response=$(curl -s -X GET http://127.0.0.1:$port/auth/isConfigured -H "Content-Type: application/json")

--- a/scripts/install
+++ b/scripts/install
@@ -128,7 +128,7 @@ chown -R "$app:www-data" "$install_dir/dist"
 #=================================================
 
 ynh_script_progression "Setting up systemd service..." 
-yunohost service add "$app" --description="Jellystat"
+yunohost service add "$app" --description="Jellystat statistics service"
 ynh_config_add_systemd
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -167,7 +167,7 @@ ynh_print_info "Creating admin user..."
 API_TOKEN_RESPONSE=$(ynh_hide_warnings curl --silent --show-error --fail -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
 API_TOKEN=$(ynh_hide_warnings echo "$API_TOKEN_RESPONSE" | jq -r '.token')
 ynh_app_setting_set --key=api_token --value="$API_TOKEN"
-API_KEY_RESPONSE=$(ynh_hide_warnings curl --silent --show-error --fail -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{\"name\": \"YunoHost\"}')
+API_KEY_RESPONSE=$(ynh_hide_warnings curl --silent --show-error --fail -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
 API_KEY=$(ynh_hide_warnings echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
 ynh_app_setting_set --key=api_key --value="$API_KEY"
 

--- a/scripts/install
+++ b/scripts/install
@@ -167,7 +167,7 @@ ynh_print_info "Creating admin user..."
 API_TOKEN_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
 API_TOKEN=$(ynh_hide_warnings echo "$API_TOKEN_RESPONSE" | jq -r '.token')
 ynh_app_setting_set --key=api_token --value="$API_TOKEN"
-API_KEY_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
+API_KEY_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{\"name\": \"YunoHost\"}')
 API_KEY=$(ynh_hide_warnings echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
 ynh_app_setting_set --key=api_key --value="$API_KEY"
 

--- a/scripts/install
+++ b/scripts/install
@@ -166,10 +166,10 @@ done
 ynh_print_info "Creating admin user..."
 API_TOKEN_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
 API_TOKEN=$(ynh_hide_warnings echo "$API_TOKEN_RESPONSE" | jq -r '.token')
-ynh_app_setting_set --key=apitoken --value="$API_TOKEN"
+ynh_app_setting_set --key=api_token --value="$API_TOKEN"
 API_KEY_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
 API_KEY=$(ynh_hide_warnings echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
-ynh_app_setting_set --key=apikey --value="$API_KEY"
+ynh_app_setting_set --key=api_key --value="$API_KEY"
 
 # Debug the advanced state
 setup_state_response=$(curl -s -X GET http://127.0.0.1:$port/auth/isConfigured -H "Content-Type: application/json")

--- a/scripts/install
+++ b/scripts/install
@@ -164,11 +164,11 @@ done
 
 # Create the admin user
 ynh_print_info "Creating admin user..."
-API_TOKEN_RESPONSE=$(curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
-API_TOKEN=$(echo "$API_TOKEN_RESPONSE" | jq -r '.token')
+API_TOKEN_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
+API_TOKEN=$(ynh_hide_warnings echo "$API_TOKEN_RESPONSE" | jq -r '.token')
 ynh_app_setting_set --app=$app --key=apitoken --value="$API_TOKEN"
-API_KEY_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
-API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
+API_KEY_RESPONSE=$(ynh_hide_warnings curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
+API_KEY=$(ynh_hide_warnings echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
 ynh_app_setting_set --app=$app --key=apikey --value="$API_KEY"
 
 # Debug the advanced state

--- a/scripts/install
+++ b/scripts/install
@@ -164,9 +164,12 @@ done
 
 # Create the admin user
 ynh_print_info "Creating admin user..."
-curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}'
-API_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -d '{"name": "YunoHost"}')
-API_KEY=$(echo "$API_RESPONSE" | jq -r '.[-1].key')
+API_TOKEN_RESPONSE=$(curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
+API_TOKEN=$(echo "$API_TOKEN_RESPONSE" | jq -r '.token')
+ynh_app_setting_set --app=$app --key=apitoken --value="$API_TOKEN"
+API_KEY_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
+API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
+ynh_app_setting_set --app=$app --key=apikey --value="$API_KEY"
 
 # Debug the advanced state
 setup_state_response=$(curl -s -X GET http://127.0.0.1:$port/auth/isConfigured -H "Content-Type: application/json")

--- a/scripts/install
+++ b/scripts/install
@@ -165,8 +165,8 @@ done
 # Create the admin user
 ynh_print_info "Creating admin user..."
 curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}'
-API_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -d '{"name": "YunoHost"}' --silent)
-API_KEY=$(echo "$API_RESPONSE" | jq -r '.[-1].key' --silent)
+API_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -d '{"name": "YunoHost"}')
+API_KEY=$(echo "$API_RESPONSE" | jq -r '.[-1].key')
 
 # Debug the advanced state
 setup_state_response=$(curl -s -X GET http://127.0.0.1:$port/auth/isConfigured -H "Content-Type: application/json")

--- a/scripts/install
+++ b/scripts/install
@@ -164,8 +164,8 @@ done
 
 # Create the admin user
 ynh_print_info "Creating admin user..."
-curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"})'
-API_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -d '{"name": "YunoHost"} --silent)'
+curl -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}'
+API_RESPONSE=$(curl -X POST http://127.0.0.1:$port/keys -H "Content-Type: application/json" -d '{"name": "YunoHost"}' --silent)
 API_KEY=$(echo "$API_RESPONSE" | jq -r '.[-1].key' --silent)
 
 # Debug the advanced state

--- a/scripts/install
+++ b/scripts/install
@@ -128,6 +128,7 @@ chown -R "$app:www-data" "$install_dir/dist"
 #=================================================
 
 ynh_script_progression "Setting up systemd service..." 
+yunohost service add "$app" --description="Jellystat"
 ynh_config_add_systemd
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -162,16 +162,22 @@ for i in {1..30}; do
     fi
 done
 
-# Create the admin user
-ynh_print_info "Creating admin user..."
+#=================================================
+# SETUP USER AND API
+#=================================================
+ynh_script_progression "Starting setup for User and API..."
+
+ynh_print_info "Creating admin user and saving token..."
 API_TOKEN_RESPONSE=$(ynh_hide_warnings curl --silent --show-error --fail -X POST http://127.0.0.1:$port/auth/createuser -H "Content-Type: application/json" -d '{"username": "'"$js_user"'", "password": "'"$js_password"'"}')
 API_TOKEN=$(ynh_hide_warnings echo "$API_TOKEN_RESPONSE" | jq -r '.token')
 ynh_app_setting_set --key=api_token --value="$API_TOKEN"
+
+ynh_print_info "Creating and saving API key..."
 API_KEY_RESPONSE=$(ynh_hide_warnings curl --silent --show-error --fail -X POST http://127.0.0.1:$port/api/keys -H "Content-Type: application/json" -H "Authorization: Bearer $API_TOKEN" -d '{"name": "YunoHost"}')
 API_KEY=$(ynh_hide_warnings echo "$API_KEY_RESPONSE" | jq -r '.[-1].key')
 ynh_app_setting_set --key=api_key --value="$API_KEY"
 
-# Debug the advanced state
+ynh_print_info "Verifying whether setup was completed..."
 setup_state_response=$(curl -s -X GET http://127.0.0.1:$port/auth/isConfigured -H "Content-Type: application/json")
 ynh_print_warn "Setup state response: $setup_state_response"
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -20,7 +20,7 @@ if systemctl is-active --quiet "$app"; then
     ynh_systemctl --service="$app" --action="stop"
 fi
 
-yunohost service remove "$app"
+ynh_hide_warnings yunohost service remove "$app"
 ynh_config_remove_systemd
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -20,7 +20,9 @@ if systemctl is-active --quiet "$app"; then
     ynh_systemctl --service="$app" --action="stop"
 fi
 
-ynh_hide_warnings yunohost service remove "$app"
+if ynh_hide_warnings yunohost service status "$app" >/dev/null; then
+    yunohost service remove "$app"
+fi
 ynh_config_remove_systemd
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -20,6 +20,7 @@ if systemctl is-active --quiet "$app"; then
     ynh_systemctl --service="$app" --action="stop"
 fi
 
+yunohost service remove "$app"
 ynh_config_remove_systemd
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -14,7 +14,6 @@ source /usr/share/yunohost/helpers
 ynh_script_progression "Restoring the app main directory..."
 
 ynh_restore "$install_dir"
-ynh_restore "$data_dir"
 
 # Retrieve database and user values from the app setting
 postgres_db=$(ynh_app_setting_get --app=$app --key=postgres_db)

--- a/scripts/restore
+++ b/scripts/restore
@@ -28,9 +28,6 @@ ynh_script_progression "Restoring the environment variables file..."
 chmod 600 "$install_dir/.env"
 chown "$app:$app" "$install_dir/.env"
 
-# Set permissions for data_dir
-chown "$app:$app" "$data_dir"
-
 # Set permissions for the entire install directory
 chown -R "$app:$app" "$install_dir"
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -90,7 +90,7 @@ ynh_nodejs_install
 # RELOAD AND START SERVICES
 #=================================================
 ynh_script_progression "Reloading and starting services..."
-
+yunohost service add "$app" --description="Jellystat statistics service"
 ynh_systemctl --service="$app" --action="start" --log_path="systemd" --timeout=30
 ynh_systemctl --service=nginx --action=reload
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -92,6 +92,7 @@ chown -R "$app:www-data" "$install_dir/dist"
 ynh_script_progression "Configuring $app's systemd service..."
 
 # Create a dedicated systemd config
+yunohost service add "$app" --description="Jellystat statistics service"
 ynh_config_add_systemd
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -86,9 +86,6 @@ chown -R "$app:$app" "$install_dir"
 # Adjust permissions for web-accessible directories
 chown -R "$app:www-data" "$install_dir/dist"
 
-# Adjust permissions for data
-chown -R "$app:$app" "$data_dir"
-
 #=================================================
 # CONFIGURE SYSTEMD SERVICE
 #=================================================


### PR DESCRIPTION
## Problem

- *Update from upstream 1.1.3*
- *No API key is created on install*
- *Obsolete data_dir*
- *No info printed for user during user and API key/token setup*

## Solution

- *Update tar.gz link and hash*
- *Add a POST request to create an API key on the app during install*
- *Remove data_dir from scripts and manifest*
- *Add script progression / info messages for user during user / API setup*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
